### PR TITLE
Changed password length to fit md5 hash

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,7 +14,7 @@ CREATE TABLE users
 (
   id int NOT NULL AUTO_INCREMENT,
   username varchar(30),
-  `password` varchar(30),
+  `password` varchar(32),
   PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
An md5 hash is 32 characters long, but the CREATE TABLE statement in the README only has a length of 30 characters in the password field. Changed it accordingly.